### PR TITLE
#83

### DIFF
--- a/R/find_best_model.lmerModLmerTest.R
+++ b/R/find_best_model.lmerModLmerTest.R
@@ -38,7 +38,7 @@ find_best_model.lmerModLmerTest <- function(fit, interaction=TRUE, fixed=NULL, .
 
   
   # Recreating the dataset without NA
-  dataComplete <- get_all_vars(fit)[complete.cases(get_all_vars(fit)), ]
+  dataComplete <- fit@frame[complete.cases(fit@frame), ]
   
   
   # fit models


### PR DESCRIPTION
When the dataset was not attached, the following error was returned.

```r
data <- affective
#attach(affective)
fit <- lmer(Tolerating ~ Salary + Life_Satisfaction + Concealing + (1|Sex) + (1|Age), data=data)
best <- find_best_model(fit)
```
> Error in eval(inp, data, env) : object 'Tolerating' not found.

It was because of the function get_all_vars(). Hence my changes.